### PR TITLE
Fix overlay spotlight hiding logic

### DIFF
--- a/src/components/Overlay.tsx
+++ b/src/components/Overlay.tsx
@@ -102,13 +102,24 @@ export default class JoyrideOverlay extends React.Component<OverlayProps, State>
     clearTimeout(this.resizeTimeout);
     clearTimeout(this.scrollTimeout);
     this.scrollParent?.removeEventListener('scroll', this.handleScroll);
+
+    // Reset state when unmounting
+    this.updateState({ mouseOverSpotlight: false });
   }
 
   hideSpotlight = () => {
-    const { disableOverlay, lifecycle } = this.props;
+    const { continuous, disableOverlay, lifecycle } = this.props;
     const hiddenLifecycles = [LIFECYCLE.BEACON, LIFECYCLE.COMPLETE, LIFECYCLE.ERROR] as Lifecycle[];
 
-    return disableOverlay || hiddenLifecycles.includes(lifecycle);
+    const shouldHide =
+      disableOverlay ||
+      (continuous ? hiddenLifecycles.includes(lifecycle) : lifecycle !== LIFECYCLE.TOOLTIP);
+
+    if (shouldHide) {
+      this.updateState({ mouseOverSpotlight: false });
+    }
+
+    return shouldHide;
   };
 
   get overlayStyles() {


### PR DESCRIPTION
Update `hideSpotlight` function and `componentWillUnmount` method in `src/components/Overlay.tsx`.

* Add `continuous` to the destructured props in the `hideSpotlight` function.
* Update the `hiddenLifecycles` array to include `LIFECYCLE.BEACON`, `LIFECYCLE.COMPLETE`, and `LIFECYCLE.ERROR`.
* Update the `shouldHide` variable to account for the `continuous` property.
* Update the `hideSpotlight` function to return `shouldHide`.
* Add state reset for `mouseOverSpotlight` to `componentWillUnmount` method.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/maoryadin/react-joyride/pull/2?shareId=8cf55115-9e88-4358-9770-a06413d8873c).