### PR TITLE
Fix overlay component to handle spotlightClicks, disableOverlay, and lifecycle changes in componentDidUpdate

### DIFF
--- a/src/components/Overlay.tsx
+++ b/src/components/Overlay.tsx
@@ -63,7 +63,7 @@ export default class JoyrideOverlay extends React.Component<OverlayProps, State>
   }
 
   componentDidUpdate(previousProps: OverlayProps) {
-    const { disableScrollParentFix, lifecycle, spotlightClicks, target } = this.props;
+    const { disableScrollParentFix, lifecycle, target, spotlightClicks } = this.props;
     const { changed } = treeChanges(previousProps, this.props);
 
     if (changed('target') || changed('disableScrollParentFix')) {
@@ -85,10 +85,13 @@ export default class JoyrideOverlay extends React.Component<OverlayProps, State>
     }
 
     if (changed('spotlightClicks') || changed('disableOverlay') || changed('lifecycle')) {
+      window.removeEventListener('mousemove', this.handleMouseMove);
+
+      // Reset mouseOverSpotlight state when lifecycle changes or spotlightClicks changes
+      this.updateState({ mouseOverSpotlight: false });
+
       if (spotlightClicks && lifecycle === LIFECYCLE.TOOLTIP) {
         window.addEventListener('mousemove', this.handleMouseMove, false);
-      } else if (lifecycle !== LIFECYCLE.TOOLTIP) {
-        window.removeEventListener('mousemove', this.handleMouseMove);
       }
     }
   }


### PR DESCRIPTION
Refactor `componentDidUpdate` method in `src/components/Overlay.tsx` to handle `spotlightClicks`, `disableOverlay`, and `lifecycle` changes.

* Add logic to remove `mousemove` event listener and reset `mouseOverSpotlight` state when `spotlightClicks` or `lifecycle` changes.
* Add logic to add `mousemove` event listener when `spotlightClicks` is true and `lifecycle` is `LIFECYCLE.TOOLTIP`.
* Remove redundant `mousemove` event listener removal logic.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/maoryadin/react-joyride/pull/3?shareId=ff03befd-7202-424d-925a-ead5793e57af).